### PR TITLE
fix: setting default dimensions as empty array

### DIFF
--- a/src/Builder/PayloadBuilder.php
+++ b/src/Builder/PayloadBuilder.php
@@ -7,7 +7,7 @@ use NorbyBaru\AwsTimestream\Contract\PayloadBuilderContract;
 
 final class PayloadBuilder implements PayloadBuilderContract
 {
-    protected array $dimensions;
+    protected array $dimensions = [];
 
     public function __construct(
         protected string $measureName,
@@ -18,8 +18,6 @@ final class PayloadBuilder implements PayloadBuilderContract
     ) {
         if ($dimensions) {
             collect($dimensions)->each(fn ($value, $key) => $this->buildDimensions($key, $value));
-        } else {
-            $this->dimensions = [];
         }
     }
 

--- a/src/Builder/PayloadBuilder.php
+++ b/src/Builder/PayloadBuilder.php
@@ -18,6 +18,8 @@ final class PayloadBuilder implements PayloadBuilderContract
     ) {
         if ($dimensions) {
             collect($dimensions)->each(fn ($value, $key) => $this->buildDimensions($key, $value));
+        } else {
+            $this->dimensions = [];
         }
     }
 

--- a/tests/Unit/PayloadBuilderUnitTest.php
+++ b/tests/Unit/PayloadBuilderUnitTest.php
@@ -19,7 +19,6 @@ class PayloadBuilderUnitTest extends TestCase
             'DOUBLE'
         );
 
-
         try {
             $metric = $payloadBuilder->toArray(true);
         } catch (\Exception $e) {

--- a/tests/Unit/PayloadBuilderUnitTest.php
+++ b/tests/Unit/PayloadBuilderUnitTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace NorbyBaru\AwsTimestream\Tests\Unit;
+
+use Illuminate\Support\Carbon;
+use NorbyBaru\AwsTimestream\Builder\PayloadBuilder;
+use NorbyBaru\AwsTimestream\Tests\TestCase;
+
+class PayloadBuilderUnitTest extends TestCase
+{
+    public function test_it_has_initialized_correctly()
+    {
+        // create a time of "2024-01-11T15:49:17+00:00" (that equals to 1704988157000)
+        $time = Carbon::create(2024, 1, 11, 15, 49, 17, 'UTC');
+        $payloadBuilder = PayloadBuilder::make(
+            'test',
+            1,
+            $time,
+            'DOUBLE'
+        );
+
+
+        try {
+            $metric = $payloadBuilder->toArray(true);
+        } catch (\Exception $e) {
+            $this->fail($e->getMessage());
+        }
+
+        $this->assertIsArray($metric);
+        $this->assertArrayHasKey('MeasureName', $metric);
+        $this->assertArrayHasKey('MeasureValue', $metric);
+        $this->assertArrayHasKey('MeasureValueType', $metric);
+        $this->assertArrayHasKey('Time', $metric);
+        $this->assertArrayHasKey('Dimensions', $metric);
+
+        $this->assertEquals('test', $metric['MeasureName']);
+        $this->assertEquals('1', $metric['MeasureValue']);
+        $this->assertEquals('DOUBLE', $metric['MeasureValueType']);
+        $this->assertEquals("1704988157000", $metric['Time']);
+        $this->assertEmpty($metric['Dimensions']);
+    }
+}


### PR DESCRIPTION
setting default dimensions as empty array, if not provided (or provided as empty)

(#33)