### PR TITLE
Replace collect() calls with plain array operations in non-collection hot paths

### DIFF
--- a/src/Builder/PayloadBuilder.php
+++ b/src/Builder/PayloadBuilder.php
@@ -43,13 +43,13 @@ final class PayloadBuilder implements PayloadBuilderContract
 
     public static function buildCommonAttributes(array $attributes): array
     {
-        $metrics = array_values(array_map(function ($key, $value) {
+        $metrics = array_map(function ($key, $value) {
             return [
                 'DimensionValueType' => 'VARCHAR',
                 'Name' => $key,
                 'Value' => (string) $value,
             ];
-        }, array_keys($attributes), $attributes));
+        }, array_keys($attributes), $attributes);
 
         return [
             'Dimensions' => $metrics,

--- a/src/Builder/PayloadBuilder.php
+++ b/src/Builder/PayloadBuilder.php
@@ -43,16 +43,13 @@ final class PayloadBuilder implements PayloadBuilderContract
 
     public static function buildCommonAttributes(array $attributes): array
     {
-        $metrics = collect($attributes)
-            ->map(function ($value, $key) {
-                return [
-                    'DimensionValueType' => 'VARCHAR',
-                    'Name' => $key,
-                    'Value' => (string) $value,
-                ];
-            })
-            ->values()
-            ->all();
+        $metrics = array_values(array_map(function ($key, $value) {
+            return [
+                'DimensionValueType' => 'VARCHAR',
+                'Name' => $key,
+                'Value' => (string) $value,
+            ];
+        }, array_keys($attributes), $attributes));
 
         return [
             'Dimensions' => $metrics,

--- a/src/Builder/PayloadBuilder.php
+++ b/src/Builder/PayloadBuilder.php
@@ -17,7 +17,9 @@ final class PayloadBuilder implements PayloadBuilderContract
         array $dimensions = []
     ) {
         if ($dimensions) {
-            collect($dimensions)->each(fn ($value, $key) => $this->buildDimensions($key, $value));
+            foreach ($dimensions as $key => $value) {
+                $this->buildDimensions($key, $value);
+            }
         }
     }
 

--- a/src/TimestreamBuilder.php
+++ b/src/TimestreamBuilder.php
@@ -12,17 +12,17 @@ class TimestreamBuilder
 {
     public static function batchPayload(array $metrics): array
     {
-        return collect($metrics)
-            ->map(
-                fn ($metric) =>
-                self::payload(
-                    $metric['measure_name'],
-                    $metric['measure_value'],
-                    $metric['time'],
-                    $metric['measure_value_type'] ?? 'VARCHAR',
-                    $metric['dimensions'] ?? []
-                )->toArray(true)
-            )->all();
+        return array_map(
+            fn ($metric) =>
+            self::payload(
+                $metric['measure_name'],
+                $metric['measure_value'],
+                $metric['time'],
+                $metric['measure_value_type'] ?? 'VARCHAR',
+                $metric['dimensions'] ?? []
+            )->toArray(true),
+            $metrics
+        );
     }
 
     public static function payload(

--- a/src/TimestreamService.php
+++ b/src/TimestreamService.php
@@ -48,14 +48,13 @@ class TimestreamService
         } catch (TimestreamWriteException $e) {
             $records = $payload['Records'];
             if ($e->getAwsErrorCode() === 'RejectedRecordsException') {
-                $records = collect($e->get('RejectedRecords'))
-                    ->map(function ($data) use ($records) {
-                        return [
-                            'RecordIndex' => $data['RecordIndex'],
-                            'Record' => $records[$data['RecordIndex']],
-                            'Reason' => $data['Reason'],
-                        ];
-                    })->all();
+                $records = array_map(function ($data) use ($records) {
+                    return [
+                        'RecordIndex' => $data['RecordIndex'],
+                        'Record' => $records[$data['RecordIndex']],
+                        'Reason' => $data['Reason'],
+                    ];
+                }, $e->get('RejectedRecords'));
             }
 
             throw new FailTimestreamWriterException($e, $records);


### PR DESCRIPTION
Several methods use Laravel's `collect()` helper for simple array operations that don't benefit from Collection's fluent API. In `PayloadBuilder::buildCommonAttributes()`, `TimestreamBuilder::batchPayload()`, `PayloadBuilder::__construct()`, and the error handling in `ingest()`, Collection objects are created for simple map/each operations on small arrays.